### PR TITLE
AreaRestrictor only calls setPosition() if it has changed

### DIFF
--- a/src/views/basics/positioners/AreaRestrictor.cpp
+++ b/src/views/basics/positioners/AreaRestrictor.cpp
@@ -34,5 +34,7 @@ void AreaRestrictor::restrict(BasicScreenObject *_object) {
     newpos.y = (restarea.y + restarea.height) - (srcarea.y + srcarea.height);
   }
 
-  _object->setPosition(newpos);
+  if (_object->getPosition() != newpos) {
+    _object->setPosition(newpos);
+  }
 };


### PR DESCRIPTION
This prevents a ScrollableContainer from thinking its contents have moved every frame (among other things, I'm sure)
